### PR TITLE
Switch from envconfig to envdecode pkg

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,23 +3,25 @@ package config
 import (
 	"log"
 
-	"github.com/kelseyhightower/envconfig"
+	"github.com/joeshaw/envdecode"
 )
 
 // Config represent the application configuration
 type Config struct {
-	Debug       bool   `envconfig:"debug" default:"0"`
-	Tags        string `envconfig:"tags" default:"Name=*"`
-	SSHUsername string `envconfig:"ssh_username" default:"ec2-user"`
-	SSHPort     string `envconfig:"ssh_port" default:"22"`
-	SSHOpts     string `envconfig:"ssh_opts" default:"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5"`
+	Debug       bool   `env:"AWSSH_DEBUG,default=0"`
+	Tags        string `env:"AWSS_TAGS,default=Name=*"`
+	SSHUsername string `env:"AWSSH_SSH_USERNAME,default=ec2-user"`
+	SSHPort     string `env:"AWSSH_SSH_PORT,default=22"`
+	SSHOpts     string `env:"AWSSH_SSH_OPTS,default=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5"`
+	Region      string `env:"AWS_DEFAULT_REGION"`
 }
 
 var appConfig Config
 
 // Load used to load the application configuration
 func Load() {
-	if err := envconfig.Process("awssh", &appConfig); err != nil {
+
+	if err := envdecode.Decode(&appConfig); err != nil {
 		log.Fatal("Can't load config: ", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.33.19
+	github.com/joeshaw/envdecode v0.0.0-20200121155833-099f1fc765bd
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/manifoldco/promptui v0.7.0
 	github.com/morikuni/aec v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/joeshaw/envdecode v0.0.0-20200121155833-099f1fc765bd h1:nIzoSW6OhhppWLm4yqBwZsKJlAayUu5FGozhrF3ETSM=
+github.com/joeshaw/envdecode v0.0.0-20200121155833-099f1fc765bd/go.mod h1:MEQrHur0g8VplbLOv5vXmDzacSaH9Z7XhcgsSh1xciU=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -15,7 +15,6 @@ import (
 
 var (
 	usePublicIP bool
-	region      string
 	appConfig   *config.Config
 )
 
@@ -50,12 +49,12 @@ func MakeRoot() *cobra.Command {
 	command.Run = runSSHAccess
 
 	command.Flags().BoolVarP(&appConfig.Debug, "debug", "d", appConfig.Debug, "Enabled debug mode")
+	command.Flags().StringVar(&appConfig.Region, "region", appConfig.Region, "Default AWS region to be used. Either set AWS_REGION or AWS_DEFAULT_REGION")
 	command.Flags().StringVarP(&appConfig.Tags, "tags", "t", appConfig.Tags, "EC2 tags key-value pair")
 	command.Flags().StringVarP(&appConfig.SSHUsername, "ssh-username", "u", appConfig.SSHUsername, "EC2 SSH username")
 	command.Flags().StringVarP(&appConfig.SSHPort, "ssh-port", "p", appConfig.SSHPort, "An EC2 instance ssh port")
 	command.Flags().StringVarP(&appConfig.SSHOpts, "ssh-opts", "o", appConfig.SSHOpts, "An additional ssh options")
 	command.Flags().BoolVarP(&usePublicIP, "use-public-ip", "", false, "Use public IP to access the EC2 instance")
-	command.Flags().StringVarP(&region, "region", "", "", "Default AWS region to be used. Either set AWS_REGION or AWS_DEFAULT_REGION")
 
 	return command
 }
@@ -81,7 +80,7 @@ func runSSHAccess(cmd *cobra.Command, args []string) {
 
 	var target *aws.EC2Instance
 
-	session := aws.NewSession(region)
+	session := aws.NewSession(appConfig.Region)
 
 	if len(args) > 0 {
 		instances, err := aws.GetInstanceWithID(session, args[0])


### PR DESCRIPTION
With the switch to `envdecode` package from `envconfig`, we could add `AWS_DEFAULT_REGION` as our default value for `Region`